### PR TITLE
Change max http header size to 1M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN apk add --update 'nodejs<13.0.0'
 EXPOSE 80
 
 ENV APP__ENV_NAME=prod
-CMD node -r esm src/api.js
+CMD node --max-http-header-size=1048576 -r esm src/api.js


### PR DESCRIPTION
This MR is to fix errors on large buffer sizes when you push it with large cookies. Without it it will return 431 error.