### PR TITLE
fix: correct ocurred→occurred typo in error message

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -49,7 +49,7 @@ export async function init () {
                 return next(err);
             }
             error(err);
-            return res.status(500).send({ error: "An error ocurred. Error info was logged." });
+            return res.status(500).send({ error: "An error occurred. Error info was logged." });
         });
 
         app.listen(config.httpPort, function onReady () {


### PR DESCRIPTION
## Summary
Fix typo in src/api.js: ocurred→occurred in 500 error response body.

Before: An error ocurred. Error info was logged.
After: An error occurred. Error info was logged.

1 file, 1 line change. User-facing error message.